### PR TITLE
Changed print statements for Python 3 compatibility

### DIFF
--- a/mandelbrot_numba.ipynb
+++ b/mandelbrot_numba.ipynb
@@ -128,7 +128,7 @@
     "create_fractal(-2.0, 1.0, -1.0, 1.0, image, 20) \n",
     "dt = timer() - start\n",
     "\n",
-    "print \"Mandelbrot created in %f s\" % dt\n",
+    "print(\"Mandelbrot created in %f s\" % dt)\n",
     "imshow(image)\n",
     "show()"
    ]
@@ -262,7 +262,7 @@
     "create_fractal(-2.0, 1.0, -1.0, 1.0, image, 20) \n",
     "dt = timer() - start\n",
     "\n",
-    "print \"Mandelbrot created in %f s\" % dt\n",
+    "print(\"Mandelbrot created in %f s\" % dt)\n",
     "imshow(image)\n",
     "show()"
    ]
@@ -420,7 +420,7 @@
     "d_image.to_host()\n",
     "dt = timer() - start\n",
     "\n",
-    "print \"Mandelbrot created on GPU in %f s\" % dt\n",
+    "print(\"Mandelbrot created on GPU in %f s\" % dt)\n",
     "\n",
     "imshow(gimage)\n",
     "show()"


### PR DESCRIPTION
I added parentheses to the `print` statements to make them compatible with Python 3. This syntax is still compatible with at least Python 2.7 as well.