### PR TITLE
Update mandelbrot_numba.ipynb

### DIFF
--- a/mandelbrot_numba.ipynb
+++ b/mandelbrot_numba.ipynb
@@ -190,9 +190,9 @@
    },
    "outputs": [],
    "source": [
-    "from numba import autojit\n",
+    "from numba import jit\n",
     "\n",
-    "@autojit\n",
+    "@jit\n",
     "def mandel(x, y, max_iters):\n",
     "  \"\"\"\n",
     "    Given the real and imaginary parts of a complex number,\n",
@@ -208,7 +208,7 @@
     "\n",
     "  return max_iters\n",
     "\n",
-    "@autojit\n",
+    "@jit\n",
     "def create_fractal(min_x, max_x, min_y, max_y, image, iters):\n",
     "  height = image.shape[0]\n",
     "  width = image.shape[1]\n",
@@ -228,7 +228,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's run the `@autojit` code and see if it is faster."
+    "Let's run the `@jit` code and see if it is faster."
    ]
   },
   {
@@ -417,7 +417,7 @@
     "start = timer()\n",
     "d_image = cuda.to_device(gimage)\n",
     "mandel_kernel[griddim, blockdim](-2.0, 1.0, -1.0, 1.0, d_image, 20) \n",
-    "d_image.to_host()\n",
+    "d_image.copy_to_host()\n",
     "dt = timer() - start\n",
     "\n",
     "print \"Mandelbrot created on GPU in %f s\" % dt\n",


### PR DESCRIPTION
autojit is deprecated now (2021) so I've changed any mentions from autojit to jit

In the last code block for the cuda example :
'DeviceNDArray' object has no attribute 'to_host'
- it needs to be renamed to copy_to_host()
but I just get a purple image as a result, maybe the mandelbrot function isn't running in GPU/kernel