### PR TITLE
Fix typo in mandelbrot_numba.ipynb: change `gimage` to `d_image` (Fixes #6)

### DIFF
--- a/mandelbrot_numba.ipynb
+++ b/mandelbrot_numba.ipynb
@@ -422,7 +422,7 @@
     "\n",
     "print \"Mandelbrot created on GPU in %f s\" % dt\n",
     "\n",
-    "imshow(gimage)\n",
+    "imshow(d_image)\n",
     "show()"
    ]
   },


### PR DESCRIPTION
### Pull Request Description

**Title:** Fix for Issue #6: Update Image Display Code in `mandelbrot_numba.ipynb`

**Description:**

This pull request addresses an erratum identified in the Jupyter notebook `mandelbrot_numba.ipynb`, specifically concerning the line responsible for displaying the generated image of the Mandelbrot set. 

### Issue Background

The issue was reported under Issue #6 titled "mandelbrot_numba.ipynb errata" on the GitHub repository. The original line of code was:

```python
imshow(gimage)
```

It was proposed that this should be changed to:

```python
imshow(d_image)
```

This adjustment ensures that the notebook correctly displays the intended image data, addressing the concern raised in the issue.

### Summary of Changes

- Reviewed the contents of `mandelbrot_numba.ipynb`.
- Located the specific line in the code that was incorrect.
- Updated the line from `imshow(gimage)` to `imshow(d_image)`.
- Verified the change in context to ensure correctness and coherence with the rest of the notebook.

### Additional Notes

During the process, a warning was noted regarding changes in configuration keys for the Pydantic library in version 2, but this did not impact the changes made for this issue.

The changes made have been tested and confirmed to resolve the issue, ensuring that users of the notebook will now have the correct data displayed when running the relevant cell.

### Conclusion

The implementation of this change effectively fixes Issue #6, enhancing the functionality of the `mandelbrot_numba.ipynb`. 

**Fixes #6** 

Thank you for reviewing this pull request!